### PR TITLE
Regex was only testing first character

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -24,7 +24,7 @@ validators = {
         Required(),
         Length(min=6, max=50),
         EqualTo('confirm', message='Passwords must match'),
-        Regexp(r'[A-Za-z0-9@#$%^&+=]',
+        Regexp(r'^[A-Za-z0-9@#$%^&+=]+$',
                message='Password contains invalid characters')
     ]
 }


### PR DESCRIPTION
In my application I'm doing the following: 

```
class ExtendedRegisterForm(RegisterForm):
    username = StringField('Username', [DataRequired(), Length(min=3, max=50),
                                        Regexp(r'^[A-Za-z0-9@#$%^&+=]+$', message='Username contains invalid characters'),
                                        UniqueUsername(message='Username taken')
                                        ])
```

and came across your similar code in searching http://nullege.com/codes/search/wtforms.validators.Regexp

I'm not 100%, but I think you may have the same issue that I had. I was overriding flask-security and using the above regex without the ^$ to denote start/stop and it was validating the field even if there were invalid characters.  So long as the first character matched the pattern it came back valid (but subsequent characters could be invalid and the form would still validate).
